### PR TITLE
Add default landing page for new domains

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SMRT Payments</title>
+    <link rel="icon" href="/assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="/assets/custom.css">
+</head>
+<body>
+    <h1>Welcome to SMRT Payments</h1>
+    <p><a href="/order">Order Hardware</a></p>
+    <div id="cto-signature"><img src="/assets/cto.sig.png" alt="Signature"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal `assets/index.html` so install scripts can copy it for new domains

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684a9bc1015c832a930806471ba758be