### PR TITLE
Remove leftover footer markers

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -53,4 +53,3 @@ This package deploys the complete multi-domain webserv stack:
 
 ---
 
-End of README_DEPLOY.md.

--- a/assets/IPOSPayIntegration.py
+++ b/assets/IPOSPayIntegration.py
@@ -30,4 +30,3 @@ class IPOSPayIntegration:
         response.raise_for_status()
         return response.json()
 
-End of IPOSPayIntegration.py.

--- a/assets/ascii-art.txt
+++ b/assets/ascii-art.txt
@@ -31,4 +31,3 @@
 
 Always be SMRT. Always be kind.
 
-End of ascii-art.txt.

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -50,4 +50,3 @@ footer {
 
 /* Additional site-wide styles may be appended here */
 
-End of /var/www/assets/custom.css.

--- a/assets/hack-elevenlabs.js
+++ b/assets/hack-elevenlabs.js
@@ -1,4 +1,3 @@
 <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 <elevenlabs-convai agent-id="AGENT_ID_FOR_DOMAIN"></elevenlabs-convai>
 
-End of hack-elevenlabs.js.

--- a/webserv_deploy/BUILD_MANIFEST.md
+++ b/webserv_deploy/BUILD_MANIFEST.md
@@ -106,4 +106,3 @@ This bundle deploys the complete multi-domain webserv stack:
 
 ---
 
-End of BUILD_MANIFEST.md.

--- a/webserv_deploy/README_DEPLOY.md
+++ b/webserv_deploy/README_DEPLOY.md
@@ -53,4 +53,3 @@ This package deploys the complete multi-domain webserv stack:
 
 ---
 
-End of README_DEPLOY.md.

--- a/webserv_deploy/domain.conf_template
+++ b/webserv_deploy/domain.conf_template
@@ -45,4 +45,3 @@
     CustomLog ${APACHE_LOG_DIR}/[domain]_ssl_access.log combined
 </VirtualHost>
 
-End of vhost template.

--- a/webserv_deploy/global_includes.conf
+++ b/webserv_deploy/global_includes.conf
@@ -7,4 +7,3 @@
 # Custom CSS
 <link rel="stylesheet" type="text/css" href="/assets/custom.css">
 
-# End of global_includes.conf

--- a/webserv_deploy/webserv_deploy/ Dot.bash.rc
+++ b/webserv_deploy/webserv_deploy/ Dot.bash.rc
@@ -31,4 +31,3 @@ alias l='ls -CF'
 # Export PATH updates if needed
 # export PATH=$PATH:/custom/path/here
 
-End of .bashrc.

--- a/webserv_deploy/webserv_deploy/BUILD_MANIFEST.md
+++ b/webserv_deploy/webserv_deploy/BUILD_MANIFEST.md
@@ -106,4 +106,3 @@ This bundle deploys the complete multi-domain webserv stack:
 
 ---
 
-End of BUILD_MANIFEST.md.

--- a/webserv_deploy/webserv_deploy/Dot.vimrc
+++ b/webserv_deploy/webserv_deploy/Dot.vimrc
@@ -13,4 +13,3 @@ set incsearch
 set hlsearch
 set backspace=indent,eol,start
 
-End of .vimrc.

--- a/webserv_deploy/webserv_deploy/IPOSPayIntegration.py
+++ b/webserv_deploy/webserv_deploy/IPOSPayIntegration.py
@@ -30,4 +30,3 @@ class IPOSPayIntegration:
         response.raise_for_status()
         return response.json()
 
-End of IPOSPayIntegration.py.

--- a/webserv_deploy/webserv_deploy/README_DEPLOY.md
+++ b/webserv_deploy/webserv_deploy/README_DEPLOY.md
@@ -53,4 +53,3 @@ This package deploys the complete multi-domain webserv stack:
 
 ---
 
-End of README_DEPLOY.md.

--- a/webserv_deploy/webserv_deploy/ascii-art.txt
+++ b/webserv_deploy/webserv_deploy/ascii-art.txt
@@ -31,4 +31,3 @@
 
 Always be SMRT. Always be kind.
 
-End of ascii-art.txt.

--- a/webserv_deploy/webserv_deploy/custom.css
+++ b/webserv_deploy/webserv_deploy/custom.css
@@ -50,4 +50,3 @@ footer {
 
 /* Additional site-wide styles may be appended here */
 
-End of /var/www/assets/custom.css.

--- a/webserv_deploy/webserv_deploy/domain.conf_template
+++ b/webserv_deploy/webserv_deploy/domain.conf_template
@@ -45,4 +45,3 @@
     CustomLog ${APACHE_LOG_DIR}/[domain]_ssl_access.log combined
 </VirtualHost>
 
-End of vhost template.

--- a/webserv_deploy/webserv_deploy/global_includes.conf
+++ b/webserv_deploy/webserv_deploy/global_includes.conf
@@ -7,4 +7,3 @@
 # Custom CSS
 <link rel="stylesheet" type="text/css" href="/assets/custom.css">
 
-# End of global_includes.conf

--- a/webserv_deploy/webserv_deploy/hack-elevenlabs.js
+++ b/webserv_deploy/webserv_deploy/hack-elevenlabs.js
@@ -1,4 +1,3 @@
 <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 <elevenlabs-convai agent-id="AGENT_ID_FOR_DOMAIN"></elevenlabs-convai>
 
-End of hack-elevenlabs.js.


### PR DESCRIPTION
## Summary
- tidy README_DEPLOY.md variants and related docs
- drop trailing `End of ...` markers from config and asset files

## Testing
- `grep -R "End of" -n | grep -v ".pyc" | grep -v "venv" | grep -v ".ico"`

------
https://chatgpt.com/codex/tasks/task_b_684a8c90ed44832aadfe662f728aeb63