### PR TITLE
Update Flask API start path

### DIFF
--- a/webserv_deploy/BUILD_MANIFEST.md
+++ b/webserv_deploy/BUILD_MANIFEST.md
@@ -56,7 +56,7 @@ This bundle deploys the complete multi-domain webserv stack:
 ## API Server
 
 /var/www/api_server/
-├── app.py
+├── app_final.py
 ├── IPOSPayIntegration.py
 ├── api_keys.json
 ├── venv/ (Python virtual environment for Flask app)

--- a/webserv_deploy/deploy.sh
+++ b/webserv_deploy/deploy.sh
@@ -25,7 +25,7 @@ pip install flask flask-cors requests
 
 # Manual test (optional):
 # source /var/www/api_server/venv/bin/activate
-# python /var/www/api_server/app.py
+# python /var/www/api_server/app_final.py
 
 # Setup systemd service
 cp /var/www/systemd/flask-api-server.service /etc/systemd/system/

--- a/webserv_deploy/deploy_final_v2.sh
+++ b/webserv_deploy/deploy_final_v2.sh
@@ -32,7 +32,7 @@ pip install flask flask-cors requests
 # Verify Flask app for Discover eBike waiver and order form
 echo "Verifying required Flask app files..."
 REQUIRED_FILES=(
-    "/var/www/api_server/app.py"
+    "/var/www/api_server/app_final.py"
     "/var/www/api_server/IPOSPayIntegration.py"
     "/var/www/api_server/api_keys.json"
 )
@@ -46,7 +46,7 @@ done
 
 # Post verification, start Flask app (manual test)
 echo "Manual test command:"
-echo "source /var/www/api_server/venv/bin/activate && python /var/www/api_server/app.py"
+echo "source /var/www/api_server/venv/bin/activate && python /var/www/api_server/app_final.py"
 
 # Or recommend systemd service
 echo "Recommended: create systemd service flask-api-server.service in /etc/systemd/system/"
@@ -56,7 +56,7 @@ echo "sudo systemctl start flask-api-server"
 
 # Confirm API server running (basic check)
 echo "Checking if Flask API server process is running..."
-if pgrep -f "python.*app.py" > /dev/null; then
+if pgrep -f "python.*app_final.py" > /dev/null; then
     echo "Flask API server appears to be running."
 else
     echo "WARNING: Flask API server not detected running. Please start via systemd or manually."

--- a/webserv_deploy/systemd/flask-api-server.service
+++ b/webserv_deploy/systemd/flask-api-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Flask API Server
+After=network.target
+
+[Service]
+User=www-data
+Group=www-data
+WorkingDirectory=/var/www/api_server
+Environment="PATH=/var/www/api_server/venv/bin"
+ExecStart=/usr/bin/python3 /var/www/api_server/app_final.py
+
+[Install]
+WantedBy=multi-user.target

--- a/webserv_deploy/webserv_deploy/BUILD_MANIFEST.md
+++ b/webserv_deploy/webserv_deploy/BUILD_MANIFEST.md
@@ -56,7 +56,7 @@ This bundle deploys the complete multi-domain webserv stack:
 ## API Server
 
 /var/www/api_server/
-├── app.py
+├── app_final.py
 ├── IPOSPayIntegration.py
 ├── api_keys.json
 ├── venv/ (Python virtual environment for Flask app)

--- a/webserv_deploy/webserv_deploy/deploy_final_v2.sh
+++ b/webserv_deploy/webserv_deploy/deploy_final_v2.sh
@@ -32,7 +32,7 @@ pip install flask flask-cors requests
 # Verify Flask app for Discover eBike waiver and order form
 echo "Verifying required Flask app files..."
 REQUIRED_FILES=(
-    "/var/www/api_server/app.py"
+    "/var/www/api_server/app_final.py"
     "/var/www/api_server/IPOSPayIntegration.py"
     "/var/www/api_server/api_keys.json"
 )
@@ -46,7 +46,7 @@ done
 
 # Post verification, start Flask app (manual test)
 echo "Manual test command:"
-echo "source /var/www/api_server/venv/bin/activate && python /var/www/api_server/app.py"
+echo "source /var/www/api_server/venv/bin/activate && python /var/www/api_server/app_final.py"
 
 # Or recommend systemd service
 echo "Recommended: create systemd service flask-api-server.service in /etc/systemd/system/"
@@ -56,7 +56,7 @@ echo "sudo systemctl start flask-api-server"
 
 # Confirm API server running (basic check)
 echo "Checking if Flask API server process is running..."
-if pgrep -f "python.*app.py" > /dev/null; then
+if pgrep -f "python.*app_final.py" > /dev/null; then
     echo "Flask API server appears to be running."
 else
     echo "WARNING: Flask API server not detected running. Please start via systemd or manually."


### PR DESCRIPTION
## Summary
- add systemd unit file for flask-api-server
- update deployment scripts to use app_final.py
- sync build manifests with new app filename

## Testing
- `bash -n webserv_deploy/deploy.sh`
- `bash -n webserv_deploy/deploy_final_v2.sh`
- `bash -n webserv_deploy/webserv_deploy/deploy_final_v2.sh`


------
https://chatgpt.com/codex/tasks/task_b_684a8c8c60c4832ab5203520cfa19ffd