### PR TITLE
Add Flask API server and docs

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -51,6 +51,21 @@ This package deploys the complete multi-domain webserv stack:
 - To update assets or MOTDs → update /var/www/assets and commit
 - To update API server → update /var/www/api_server and commit
 
+## Local API Testing
+
+The Flask API can be started locally for development:
+
+```bash
+cd api_server
+python3 -m venv venv  # create virtual environment if needed
+source venv/bin/activate
+pip install flask flask-cors requests
+python app.py
+```
+
+The server will listen on `http://localhost:5000/charge`. Use this to test the
+order form before deploying.
+
 ---
 
 End of README_DEPLOY.md.

--- a/api_server/IPOSPayIntegration.py
+++ b/api_server/IPOSPayIntegration.py
@@ -1,0 +1,39 @@
+import json
+import os
+import requests
+
+class IPOSPayIntegration:
+    def __init__(self, domain):
+        # Attempt to load keys from /var/www/assets first
+        key_path = '/var/www/assets/api_keys.json'
+        if not os.path.exists(key_path):
+            # Fallback to local copy within api_server/
+            key_path = os.path.join(os.path.dirname(__file__), 'api_keys.json')
+        with open(key_path, 'r') as f:
+            api_keys = json.load(f)
+        # Select API key based on domain or use default
+        if domain in api_keys:
+            config = api_keys[domain]
+        else:
+            config = api_keys["default"]
+        self.api_key = config["api_key"]
+        self.base_url = config["base_url"]
+
+    def charge_token(self, merchant_id, payment_token_id, amount, currency="USD", metadata={}):
+        url = f"{self.base_url}/charge"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json"
+        }
+        payload = {
+            "merchant_id": merchant_id,
+            "payment_token_id": payment_token_id,
+            "amount": amount,
+            "currency": currency,
+            "metadata": metadata
+        }
+        response = requests.post(url, headers=headers, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+# End of IPOSPayIntegration.py.

--- a/api_server/README.md
+++ b/api_server/README.md
@@ -1,0 +1,27 @@
+# API Server
+
+This directory contains the Flask application used for the Discover eBike waiver and order form.
+
+## Running Locally
+
+1. Create and activate a Python virtual environment (if not already present):
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+2. Install dependencies:
+
+```bash
+pip install flask flask-cors requests
+```
+
+3. Start the server:
+
+```bash
+python app.py
+```
+
+The API will be available at `http://localhost:5000/charge`.
+

--- a/api_server/api_keys.json
+++ b/api_server/api_keys.json
@@ -1,0 +1,19 @@
+{
+  "default": {
+    "api_key": "YOUR-DEFAULT-API-KEY",
+    "base_url": "https://api.ipospays.com/v1"
+  },
+  "smrtpayments.com": {
+    "api_key": "API-KEY-FOR-SMRT",
+    "base_url": "https://api.ipospays.com/v1"
+  },
+  "showcase.smrtpayments.com": {
+    "api_key": "API-KEY-FOR-EBIKE",
+    "base_url": "https://api.ipospays.com/v1"
+  },
+  "order.smrtpayments.com": {
+    "api_key": "API-KEY-FOR-ORDER-FORM",
+    "base_url": "https://api.ipospays.com/v1"
+  }
+  // Add additional domains as needed.
+}

--- a/api_server/app.py
+++ b/api_server/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from IPOSPayIntegration import IPOSPayIntegration
+import socket
+
+app = Flask(__name__)
+CORS(app)
+
+@app.route('/charge', methods=['POST'])
+def charge():
+    try:
+        data = request.json
+        required_fields = ['merchant_id', 'payment_token_id', 'amount']
+        for field in required_fields:
+            if field not in data:
+                return jsonify({"error": f"Missing required field: {field}"}), 400
+
+        merchant_id = data['merchant_id']
+        payment_token_id = data['payment_token_id']
+        amount = data['amount']
+        currency = data.get('currency', 'USD')
+        metadata = data.get('metadata', {})
+
+        # Improved domain detection
+        domain = request.headers.get("Host", socket.gethostname())
+        domain = domain.split(":")[0]  # Strip port if present
+
+        ipos = IPOSPayIntegration(domain)
+        response = ipos.charge_token(merchant_id, payment_token_id, amount, currency, metadata)
+
+        return jsonify(response), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add Flask API under `api_server/app.py`
- include `IPOSPayIntegration.py` and `api_keys.json`
- provide README notes for running the API
- fix path fallback for API keys

## Testing
- `python3 -m py_compile api_server/app.py api_server/IPOSPayIntegration.py`


------
https://chatgpt.com/codex/tasks/task_b_684a8b2130c0832aaab4b073315b5ee8