### PR TITLE
Add ElevenLabs assets and update finish scripts

### DIFF
--- a/assets/elevenlabs/hack-elevenlabs.js
+++ b/assets/elevenlabs/hack-elevenlabs.js
@@ -1,0 +1,4 @@
+<script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
+<elevenlabs-convai agent-id="AGENT_ID_HACK"></elevenlabs-convai>
+
+End of hack-elevenlabs.js.

--- a/assets/elevenlabs/kjo-elevenlabs.js
+++ b/assets/elevenlabs/kjo-elevenlabs.js
@@ -1,0 +1,4 @@
+<script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
+<elevenlabs-convai agent-id="AGENT_ID_KJO"></elevenlabs-convai>
+
+End of kjo-elevenlabs.js.

--- a/assets/elevenlabs/smrt-elevenlabs.js
+++ b/assets/elevenlabs/smrt-elevenlabs.js
@@ -1,0 +1,4 @@
+<script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
+<elevenlabs-convai agent-id="AGENT_ID_SMRT"></elevenlabs-convai>
+
+End of smrt-elevenlabs.js.

--- a/webserv_deploy/finish.sh
+++ b/webserv_deploy/finish.sh
@@ -29,9 +29,16 @@ elevenlabs_map["hackserv.org"]="hack-elevenlabs.js"
 
 # Create ElevenLabs.js symlinks
 echo "Creating ElevenLabs.js symlinks..."
-for domain in "${!elevenlabs_map[@]}"; do
-    echo "Processing $domain → ${elevenlabs_map[$domain]}"
-    ln -sf /var/www/assets/elevenlabs/${elevenlabs_map[$domain]} /var/www/html/$domain/public_html/elevenlabs.js
+for domain_path in /var/www/html/*/; do
+    domain=$(basename "$domain_path")
+    for pattern in "${!elevenlabs_map[@]}"; do
+        if [[ "$domain" == *"$pattern" ]]; then
+            target="/var/www/assets/elevenlabs/${elevenlabs_map[$pattern]}"
+            ln -sf "$target" "/var/www/assets/elevenlabs/${domain}-elevenlabs.js"
+            ln -sf "/var/www/assets/elevenlabs/${domain}-elevenlabs.js" "/var/www/html/$domain/elevenlabs.js"
+            break
+        fi
+    done
 done
 
 
@@ -58,7 +65,7 @@ favicons_map["hackserv.org"]="favicon-hack.ico"
 echo "Creating favicon.ico symlinks..."
 for domain in "${!favicons_map[@]}"; do
     echo "Processing $domain → ${favicons_map[$domain]}"
-    ln -sf /var/www/assets/favicons/${favicons_map[$domain]} /var/www/html/$domain/public_html/favicon.ico
+    ln -sf /var/www/assets/favicons/${favicons_map[$domain]} /var/www/html/$domain/favicon.ico
 done
 
 

--- a/webserv_deploy/finish_updated.sh
+++ b/webserv_deploy/finish_updated.sh
@@ -29,9 +29,16 @@ elevenlabs_map["hackserv.org"]="hack-elevenlabs.js"
 
 # Create ElevenLabs.js symlinks
 echo "Creating ElevenLabs.js symlinks..."
-for domain in "${!elevenlabs_map[@]}"; do
-    echo "Processing $domain → ${elevenlabs_map[$domain]}"
-    ln -sf /var/www/assets/elevenlabs/${elevenlabs_map[$domain]} /var/www/html/$domain/public_html/elevenlabs.js
+for domain_path in /var/www/html/*/; do
+    domain=$(basename "$domain_path")
+    for pattern in "${!elevenlabs_map[@]}"; do
+        if [[ "$domain" == *"$pattern" ]]; then
+            target="/var/www/assets/elevenlabs/${elevenlabs_map[$pattern]}"
+            ln -sf "$target" "/var/www/assets/elevenlabs/${domain}-elevenlabs.js"
+            ln -sf "/var/www/assets/elevenlabs/${domain}-elevenlabs.js" "/var/www/html/$domain/elevenlabs.js"
+            break
+        fi
+    done
 done
 
 
@@ -58,7 +65,7 @@ favicons_map["hackserv.org"]="favicon-hack.ico"
 echo "Creating favicon.ico symlinks..."
 for domain in "${!favicons_map[@]}"; do
     echo "Processing $domain → ${favicons_map[$domain]}"
-    ln -sf /var/www/assets/favicons/${favicons_map[$domain]} /var/www/html/$domain/public_html/favicon.ico
+    ln -sf /var/www/assets/favicons/${favicons_map[$domain]} /var/www/html/$domain/favicon.ico
 done
 
 
@@ -79,7 +86,7 @@ echo "Creating SMRT_logo.png symlinks..."
 for domain in "${!smrt_logo_map[@]}"; do
     if [[ "${smrt_logo_map[$domain]}" == "yes" ]]; then
         echo "Processing $domain → SMRT_logo.png"
-        ln -sf /var/www/assets/SMRT_logo.png /var/www/html/$domain/public_html/SMRT_logo.png
+        ln -sf /var/www/assets/SMRT_logo.png /var/www/html/$domain/SMRT_logo.png
     fi
 done
 


### PR DESCRIPTION
## Summary
- add directory for generic ElevenLabs widget scripts
- generate domain-specific symlinks during finish scripts
- fix favicon and SMRT logo paths

## Testing
- `bash webserv_deploy/finish.sh`
- `bash webserv_deploy/finish_updated.sh`


------
https://chatgpt.com/codex/tasks/task_b_684a8b16c794832aa713753c80ce827c