### PR TITLE
Add order form with price lookup and fix IPOS syntax

### DIFF
--- a/assets/IPOSPayIntegration.py
+++ b/assets/IPOSPayIntegration.py
@@ -30,4 +30,3 @@ class IPOSPayIntegration:
         response.raise_for_status()
         return response.json()
 
-End of IPOSPayIntegration.py.

--- a/assets/api_keys.json
+++ b/assets/api_keys.json
@@ -15,5 +15,5 @@
     "api_key": "API-KEY-FOR-ORDER-FORM",
     "base_url": "https://api.ipospays.com/v1"
   }
-  // Add additional domains as needed.
+  
 }

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -50,4 +50,3 @@ footer {
 
 /* Additional site-wide styles may be appended here */
 
-End of /var/www/assets/custom.css.

--- a/html/order.smrtpayments.com/public_html/index.html
+++ b/html/order.smrtpayments.com/public_html/index.html
@@ -8,7 +8,6 @@
 </head>
 <body>
     <h1>SMRT Payments: Order Page</h1>
-    <p>This page will allow ISOs to place orders for NCR Aloha and Silver Essentials bundles.</p>
-    <p>Ordering system coming online soon.</p>
+    <p><a href="order.html">Click here to place your order</a></p>
 </body>
 </html>

--- a/html/order.smrtpayments.com/public_html/order.html
+++ b/html/order.smrtpayments.com/public_html/order.html
@@ -4,9 +4,81 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SMRT Order Form</title>
+    <link rel="stylesheet" href="/assets/custom.css">
 </head>
 <body>
-    <h1>Order Form Coming Soon</h1>
-    <p>The full order form will be live shortly. Please check back soon.</p>
+    <h1>Order Hardware</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Product</th>
+                <th>Type</th>
+                <th>Description</th>
+                <th>Hardware Cost</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr><td>Aloha PX15 Quick Service Pro</td><td>Bundle</td><td>PX15, EMV, Customer Display, Cash Drawer, Printer</td><td>$2,500.00</td></tr>
+            <tr><td>Aloha PX10 Table Service Core</td><td>Bundle</td><td>PX10, EMV, Customer Display, Cash Drawer, Printer</td><td>$2,200.00</td></tr>
+            <tr><td>Silver PX15 Essentials Complete</td><td>Bundle</td><td>PX15, EMV, Customer Display, Cash Drawer, Printer</td><td>$2,000.00</td></tr>
+            <tr><td>Silver PX10 Essentials Starter</td><td>Bundle</td><td>PX10, EMV, Customer Display, Cash Drawer, Printer</td><td>$1,800.00</td></tr>
+            <tr><td>Silver PX15 Essentials Starter</td><td>Bundle</td><td>PX15, EMV, Customer Display, Cash Drawer, Printer</td><td>$2,000.00</td></tr>
+            <tr><td><strong>Aloha PX15 Full-Service Deluxe</strong></td><td>Bundle</td><td>PX15, EMV, Customer Display, Cash Drawer, Printer, KDS</td><td><strong>$3,200.00</strong></td></tr>
+            <tr><td>Handheld Axium EX8000 Kit 2</td><td>Item</td><td>Includes Mobile Protector Case and Single Slot Charger</td><td>$900.00</td></tr>
+            <tr><td>Handheld Axium EX8000</td><td>Item</td><td>w/Mobile Protector Case</td><td>$825.00</td></tr>
+            <tr><td>Bixolon SRP-S300LOEK Sticky Printer Kit</td><td>Item</td><td>N/A</td><td>$500.00</td></tr>
+            <tr><td>Countertop Receipt Printer for NCR Silver</td><td>Item</td><td>Bixolon SRP 350iii</td><td>$400.00</td></tr>
+            <tr><td>Kitchen Impact Printer</td><td>Item</td><td>Bixolon SRP-275iii</td><td>$400.00</td></tr>
+            <tr><td>NCR Silver 2D Scanner</td><td>Item</td><td>Zebra DS9308 - Essential Configuration</td><td>$325.00</td></tr>
+            <tr><td>Aloha Cloud 2D Scanner</td><td>Item</td><td>Zebra DS9308 - PRO Configuration</td><td>$325.00</td></tr>
+            <tr><td>Mettler Toledo Avira S-17</td><td>Item</td><td>240oz Scale Adapter Kit</td><td>$200.00</td></tr>
+            <tr><td>Cash Drawer MS</td><td>Item</td><td>16in, 5 Bill 5 Coin</td><td>$150.00</td></tr>
+            <tr><td>Cash Drawer w/Till</td><td>Item</td><td>13"</td><td>$150.00</td></tr>
+            <tr><td>Cash Drawer Till MS</td><td>Item</td><td>16in, 5 Bill 5 Coin</td><td>$50.00</td></tr>
+            <tr><td>Cash Drawer Under Counter Mounting Bracket (M-S)</td><td>Item</td><td>16"</td><td>$50.00</td></tr>
+            <tr><td>Cash Drawer Under Counter Mounting Bracket (APG)</td><td>Item</td><td>13"</td><td>$50.00</td></tr>
+            <tr><td>Kitchen Display System (KDS)</td><td>Item</td><td>N/A</td><td>$525.00</td></tr>
+        </tbody>
+    </table>
+    <form id="orderForm">
+        <label for="name">Name:</label>
+        <input type="text" id="name" required>
+        <label for="email">Email:</label>
+        <input type="email" id="email" required>
+        <label for="merchant_id">Merchant ID:</label>
+        <input type="text" id="merchant_id" required>
+        <label for="payment_token_id">Payment Token:</label>
+        <input type="text" id="payment_token_id" required>
+        <label for="product">Product:</label>
+        <select id="product">
+            <option value="Aloha PX15 Quick Service Pro">Aloha PX15 Quick Service Pro</option>
+            <option value="Aloha PX10 Table Service Core">Aloha PX10 Table Service Core</option>
+            <option value="Silver PX15 Essentials Complete">Silver PX15 Essentials Complete</option>
+            <option value="Silver PX10 Essentials Starter">Silver PX10 Essentials Starter</option>
+            <option value="Silver PX15 Essentials Starter">Silver PX15 Essentials Starter</option>
+            <option value="Aloha PX15 Full-Service Deluxe">Aloha PX15 Full-Service Deluxe</option>
+            <option value="Handheld Axium EX8000 Kit 2">Handheld Axium EX8000 Kit 2</option>
+            <option value="Handheld Axium EX8000">Handheld Axium EX8000</option>
+            <option value="Bixolon SRP-S300LOEK Sticky Printer Kit">Bixolon SRP-S300LOEK Sticky Printer Kit</option>
+            <option value="Countertop Receipt Printer for NCR Silver">Countertop Receipt Printer for NCR Silver</option>
+            <option value="Kitchen Impact Printer">Kitchen Impact Printer</option>
+            <option value="NCR Silver 2D Scanner">NCR Silver 2D Scanner</option>
+            <option value="Aloha Cloud 2D Scanner">Aloha Cloud 2D Scanner</option>
+            <option value="Mettler Toledo Avira S-17">Mettler Toledo Avira S-17</option>
+            <option value="Cash Drawer MS">Cash Drawer MS</option>
+            <option value="Cash Drawer w/Till">Cash Drawer w/Till</option>
+            <option value="Cash Drawer Till MS">Cash Drawer Till MS</option>
+            <option value="Cash Drawer Under Counter Mounting Bracket (M-S)">Cash Drawer Under Counter Mounting Bracket (M-S)</option>
+            <option value="Cash Drawer Under Counter Mounting Bracket (APG)">Cash Drawer Under Counter Mounting Bracket (APG)</option>
+            <option value="Kitchen Display System (KDS)">Kitchen Display System (KDS)</option>
+        </select>
+        <label for="quantity">Quantity:</label>
+        <input type="number" id="quantity" value="1" min="1" required>
+        <label for="amount">Amount (USD):</label>
+        <input type="number" id="amount" step="0.01" required readonly>
+        <button type="submit">Submit Order</button>
+    </form>
+    <div id="message"></div>
+    <script src="order.js"></script>
 </body>
 </html>

--- a/html/order.smrtpayments.com/public_html/order.js
+++ b/html/order.smrtpayments.com/public_html/order.js
@@ -1,2 +1,81 @@
-// Placeholder JS for SMRT Order Form
-console.log("Order form script loaded. Full functionality coming soon.");
+// Basic order form submission to /charge endpoint with pricing lookup
+
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('orderForm');
+    const message = document.getElementById('message');
+    const productSelect = document.getElementById('product');
+    const quantityInput = document.getElementById('quantity');
+    const amountInput = document.getElementById('amount');
+
+    if (!form) return;
+
+    const pricing = {
+        'Aloha PX15 Quick Service Pro': 2500.00,
+        'Aloha PX10 Table Service Core': 2200.00,
+        'Silver PX15 Essentials Complete': 2000.00,
+        'Silver PX10 Essentials Starter': 1800.00,
+        'Silver PX15 Essentials Starter': 2000.00,
+        'Aloha PX15 Full-Service Deluxe': 3200.00,
+        'Handheld Axium EX8000 Kit 2': 900.00,
+        'Handheld Axium EX8000': 825.00,
+        'Bixolon SRP-S300LOEK Sticky Printer Kit': 500.00,
+        'Countertop Receipt Printer for NCR Silver': 400.00,
+        'Kitchen Impact Printer': 400.00,
+        'NCR Silver 2D Scanner': 325.00,
+        'Aloha Cloud 2D Scanner': 325.00,
+        'Mettler Toledo Avira S-17': 200.00,
+        'Cash Drawer MS': 150.00,
+        'Cash Drawer w/Till': 150.00,
+        'Cash Drawer Till MS': 50.00,
+        'Cash Drawer Under Counter Mounting Bracket (M-S)': 50.00,
+        'Cash Drawer Under Counter Mounting Bracket (APG)': 50.00,
+        'Kitchen Display System (KDS)': 525.00
+    };
+
+    function updateAmount() {
+        const price = pricing[productSelect.value] || 0;
+        const qty = parseInt(quantityInput.value, 10) || 0;
+        amountInput.value = (price * qty).toFixed(2);
+    }
+
+    productSelect.addEventListener('change', updateAmount);
+    quantityInput.addEventListener('input', updateAmount);
+    updateAmount();
+
+    form.addEventListener('submit', async function(event) {
+        event.preventDefault();
+        message.textContent = 'Processing...';
+
+        const data = {
+            merchant_id: document.getElementById('merchant_id').value,
+            payment_token_id: document.getElementById('payment_token_id').value,
+            amount: parseFloat(amountInput.value),
+            currency: 'USD',
+            metadata: {
+                name: document.getElementById('name').value,
+                email: document.getElementById('email').value,
+                product: productSelect.value,
+                quantity: parseInt(quantityInput.value, 10)
+            }
+        };
+
+        try {
+            const response = await fetch('/charge', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            if (response.ok) {
+                const result = await response.json();
+                message.textContent = 'Success! Charge ID: ' + (result.id || '');
+                form.reset();
+                updateAmount();
+            } else {
+                const err = await response.json();
+                message.textContent = 'Error: ' + (err.error || 'Unknown');
+            }
+        } catch (e) {
+            message.textContent = 'Network error';
+        }
+    });
+});

--- a/webserv_deploy/api_keys.json
+++ b/webserv_deploy/api_keys.json
@@ -15,5 +15,5 @@
     "api_key": "API-KEY-FOR-ORDER-FORM",
     "base_url": "https://api.ipospays.com/v1"
   }
-  // Add additional domains as needed.
+
 }

--- a/webserv_deploy/systemd/flask-api-server.service
+++ b/webserv_deploy/systemd/flask-api-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SMRT Payments Flask API Server
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/var/www/api_server
+ExecStart=/var/www/api_server/venv/bin/python /var/www/api_server/app.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/webserv_deploy/webserv_deploy/IPOSPayIntegration.py
+++ b/webserv_deploy/webserv_deploy/IPOSPayIntegration.py
@@ -30,4 +30,3 @@ class IPOSPayIntegration:
         response.raise_for_status()
         return response.json()
 
-End of IPOSPayIntegration.py.


### PR DESCRIPTION
## Summary
- strip stray text from `IPOSPayIntegration.py`
- provide pricing table and selectable products on order form
- auto-calculate amount from selected product and quantity
- clean up API key JSON files
- add systemd service file for Flask API server

## Testing
- `python3 -m py_compile assets/IPOSPayIntegration.py assets/app_final.py webserv_deploy/app_final.py webserv_deploy/webserv_deploy/IPOSPayIntegration.py webserv_deploy/webserv_deploy/app_final.py`


------
https://chatgpt.com/codex/tasks/task_b_684a7ac0d42c832a98b142d4752a4445