### PR TITLE
Add default index template and automation script

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -32,7 +32,11 @@ This package deploys the complete multi-domain webserv stack:
 - Optionally starts API server as systemd service
 - Commits post-deploy state to Git
 
-3️⃣ Verify services
+3️⃣ Run ensure_indexes.sh
+
+- Copies a default index.html into each html/* directory if missing
+
+4️⃣ Verify services
 
 - All domains and subdomains should load with valid SSL
 - API server /charge endpoint should respond correctly

--- a/ensure_indexes.sh
+++ b/ensure_indexes.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copy default index page to each html subdirectory if missing
+
+set -e
+TEMPLATE="$(dirname "$0")/index_template.html"
+HTML_DIR="$(dirname "$0")/html"
+
+for dir in "$HTML_DIR"/*; do
+    [ -d "$dir" ] || continue
+    target="$dir/index.html"
+    if [ ! -f "$target" ]; then
+        cp "$TEMPLATE" "$target"
+        echo "Created $target"
+    fi
+done

--- a/index_template.html
+++ b/index_template.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome</title>
+    <link rel="icon" href="/assets/favicon.ico" type="image/x-icon">
+    <style>
+        body { font-family: sans-serif; margin: 40px; }
+        .signature { position: fixed; bottom: 20px; right: 20px; opacity: 0.75; }
+    </style>
+</head>
+<body>
+    <h1>Welcome</h1>
+    <p>This is a default placeholder page. Content will be added soon.</p>
+    <img src="/assets/cto.sig.png" alt="Signature" class="signature">
+</body>
+</html>

--- a/webserv_deploy/README_DEPLOY.md
+++ b/webserv_deploy/README_DEPLOY.md
@@ -32,7 +32,11 @@ This package deploys the complete multi-domain webserv stack:
 - Optionally starts API server as systemd service
 - Commits post-deploy state to Git
 
-3️⃣ Verify services
+3️⃣ Run ensure_indexes.sh
+
+- Copies a default index.html into each html/* directory if missing
+
+4️⃣ Verify services
 
 - All domains and subdomains should load with valid SSL
 - API server /charge endpoint should respond correctly

--- a/webserv_deploy/webserv_deploy/README_DEPLOY.md
+++ b/webserv_deploy/webserv_deploy/README_DEPLOY.md
@@ -32,7 +32,11 @@ This package deploys the complete multi-domain webserv stack:
 - Optionally starts API server as systemd service
 - Commits post-deploy state to Git
 
-3️⃣ Verify services
+3️⃣ Run ensure_indexes.sh
+
+- Copies a default index.html into each html/* directory if missing
+
+4️⃣ Verify services
 
 - All domains and subdomains should load with valid SSL
 - API server /charge endpoint should respond correctly


### PR DESCRIPTION
## Summary
- add `index_template.html` placeholder page
- create `ensure_indexes.sh` helper to populate missing index files
- document new script as part of deployment steps

## Testing
- `bash -n ensure_indexes.sh`


------
https://chatgpt.com/codex/tasks/task_b_684a72185840832a856357c89e000b26