### PR TITLE
Add favicon and ElevenLabs asset folders

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -42,6 +42,7 @@ This package deploys the complete multi-domain webserv stack:
 
 - Symlinks used for MOTDs and ASCII art
 - Domain public_html uses symlinks for elevenlabs.js and favicons
+  stored under `/var/www/assets/elevenlabs` and `/var/www/assets/favicons`
 - API server handles both card and Google Pay token flows
 - .vimrc and .bashrc are installed per domain prompt spec
 

--- a/assets/elevenlabs/smrt-elevenlabs.js
+++ b/assets/elevenlabs/smrt-elevenlabs.js
@@ -1,0 +1,4 @@
+<script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
+<elevenlabs-convai agent-id="SMRT_AGENT_ID"></elevenlabs-convai>
+
+End of smrt-elevenlabs.js.

--- a/webserv_deploy/README_DEPLOY.md
+++ b/webserv_deploy/README_DEPLOY.md
@@ -42,6 +42,7 @@ This package deploys the complete multi-domain webserv stack:
 
 - Symlinks used for MOTDs and ASCII art
 - Domain public_html uses symlinks for elevenlabs.js and favicons
+  stored under `/var/www/assets/elevenlabs` and `/var/www/assets/favicons`
 - API server handles both card and Google Pay token flows
 - .vimrc and .bashrc are installed per domain prompt spec
 


### PR DESCRIPTION
## Summary
- add `assets/favicons` and `assets/elevenlabs` directories
- include placeholder favicon and ElevenLabs script
- document asset paths in both deployment READMEs

## Testing
- `ls -R assets | sed -n '1,20p'`

------
https://chatgpt.com/codex/tasks/task_b_684a765d2494832abef563c0b58a7125