### PR TITLE
Update deploy docs

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -38,6 +38,20 @@ This package deploys the complete multi-domain webserv stack:
 - API server /charge endpoint should respond correctly
 - MOTDs and prompts should display per domain spec
 
+4️⃣ Run finish.sh
+
+- Finalizes symlinks for ElevenLabs.js and favicons
+- Directory layout expects `/var/www/assets/elevenlabs/` and `/var/www/html/<domain>/public_html/`
+- Creates `/var/www/html/<domain>/public_html/elevenlabs.js` symlinks
+- Enable Flask API server service:
+
+  `sudo systemctl enable --now flask-api-server.service`
+
+- Verify service and symlinks:
+
+  `systemctl status flask-api-server.service`
+  `ls -l /var/www/html/<domain>/public_html/elevenlabs.js`
+
 ## Notes
 
 - Symlinks used for MOTDs and ASCII art

--- a/webserv_deploy/README_DEPLOY.md
+++ b/webserv_deploy/README_DEPLOY.md
@@ -38,6 +38,20 @@ This package deploys the complete multi-domain webserv stack:
 - API server /charge endpoint should respond correctly
 - MOTDs and prompts should display per domain spec
 
+4️⃣ Run finish.sh
+
+- Finalizes symlinks for ElevenLabs.js and favicons
+- Directory layout expects `/var/www/assets/elevenlabs/` and `/var/www/html/<domain>/public_html/`
+- Creates `/var/www/html/<domain>/public_html/elevenlabs.js` symlinks
+- Enable Flask API server service:
+
+  `sudo systemctl enable --now flask-api-server.service`
+
+- Verify service and symlinks:
+
+  `systemctl status flask-api-server.service`
+  `ls -l /var/www/html/<domain>/public_html/elevenlabs.js`
+
 ## Notes
 
 - Symlinks used for MOTDs and ASCII art


### PR DESCRIPTION
## Summary
- document using finish.sh
- include instructions to enable flask-api-server
- describe directory layout and add verification commands

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684a8b289db8832aa1e5908c270356cc