### PR TITLE
Add eBike waiver form page

### DIFF
--- a/html/smrtpayments.com/ebike/index.html
+++ b/html/smrtpayments.com/ebike/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SMRT eBike Waiver</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        h1 { color: #333; }
+        form { max-width: 600px; }
+        label { display: block; margin-top: 1rem; }
+        input, textarea { width: 100%; padding: 0.5rem; }
+        button { margin-top: 1rem; padding: 0.5rem 1rem; }
+    </style>
+</head>
+<body>
+    <h1>Discover eBike Waiver Form</h1>
+    <form method="post" action="/api/waiver">
+        <label for="name">Full Name</label>
+        <input id="name" name="name" required>
+
+        <label for="email">Email Address</label>
+        <input id="email" name="email" type="email" required>
+
+        <label for="phone">Phone Number</label>
+        <input id="phone" name="phone" type="tel" required>
+
+        <label for="signature">Electronic Signature</label>
+        <input id="signature" name="signature" required>
+
+        <label for="waiver">Waiver Agreement</label>
+        <textarea id="waiver" name="waiver" rows="6" readonly>
+I acknowledge that cycling and the use of electric bicycles involve inherent risks. 
+By signing this waiver, I release SMRTPayments and its affiliates from any liability 
+for injuries or damages that may occur during my use or demonstration of the 
+Discover eBike. I agree to wear appropriate safety gear and obey all applicable 
+laws while operating the eBike.
+        </textarea>
+
+        <label>
+            <input type="checkbox" name="agree" required>
+            I have read and agree to the terms above.
+        </label>
+
+        <button type="submit">Submit Waiver</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add eBike waiver form submitting to `/api/waiver`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684eb72463c4832a9539ee03ee42d90f