### PR TITLE
Update docs for env secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for the API server
+API_KEY=your_api_key_here
+TPN=your_tpn_here
+MID=your_mid_here
+JWT_SECRET=your_jwt_secret_here

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ This bundle deploys the complete multi-domain webserv stack:
 ├── api_keys.json
 ├── venv/ (Python virtual environment for Flask app)
 
+### Configuration
+
+API keys, TPN, MID, and JWT secrets **must** be provided via environment variables or a secrets manager. Do not commit these secrets to version control. See `.env.example` for the variables required when running the API server locally.
+
 ---
 
 ## Bash and Vim


### PR DESCRIPTION
## Summary
- instruct using environment variables or secrets manager for API keys and other secrets
- add `.env.example` placeholder for API server configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684eb16ad208832aab1370d19ad60c0b