### PR TITLE
Rename README and document deployment

### DIFF
--- a/BUILD_MANIFEST.md
+++ b/BUILD_MANIFEST.md
@@ -99,6 +99,23 @@ This bundle deploys the complete multi-domain webserv stack:
 - Post-deploy commit made after deploy.sh and Flask API server install.
 
 ---
+## Deployment
+
+### Requirements
+- Ubuntu 20.04 or newer with root or sudo access
+- Python 3.9 or later
+- DNS provider access for creating TXT records (DNS-01 challenge)
+
+### Running `install.sh`
+1. Place this repository on the target server.
+2. Execute `sudo bash install.sh` from the repository root.
+3. The script installs Apache2 and sets up the directory structure and Python environment for the API server.
+
+### Obtaining wildcard certificates
+- Use Certbot or another ACME client that supports the DNS-01 challenge.
+- Issue a wildcard certificate for each domain, e.g. `certbot certonly --dns-route53 -d "*.smrtpayments.com"`.
+- Install the resulting certificates to your Apache virtual host configuration under `/etc/letsencrypt` or another preferred location.
+
 
 ## Notes
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SMRT WebServer install script (placeholder)
+# Sets up Apache2, Python virtual environment, and installs dependencies.
+# Adjust paths as needed.
+
+set -e
+
+# Install packages
+apt-get update
+apt-get install -y apache2 python3 python3-venv git
+
+# Create directory structure
+mkdir -p /var/www/{api_server,assets,html}
+for domain in smrtpayments.com teamkjo.com kjo.ai hackserv.cc hackserv.org; do
+    mkdir -p "/var/www/html/$domain"
+    ln -s /var/www/assets/elevenlabs/$domain-elevenlabs.js "/var/www/html/$domain/elevenlabs.js" || true
+    ln -s /var/www/assets/favicons/favicon-$domain.ico "/var/www/html/$domain/favicon.ico" || true
+done
+
+# Setup Python virtual environment for API server
+python3 -m venv /var/www/api_server/venv
+source /var/www/api_server/venv/bin/activate
+pip install flask
+
+deactivate
+
+echo "Install script completed. Configure certificates and vhosts separately."


### PR DESCRIPTION
## Summary
- rename `README.md` to `BUILD_MANIFEST.md`
- add deployment instructions including install script usage and certificate info
- provide a placeholder `install.sh` for setting up the Apache/Python environment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684eb15a57e0832a87354f48b53468e6